### PR TITLE
Fixed stack memory corruption due to strcat() function

### DIFF
--- a/src/dummy.cpp
+++ b/src/dummy.cpp
@@ -777,23 +777,28 @@ void fastlane_add_scsi_unit(int, uaedev_config_info*, romconfig*) {
     UNIMPLEMENTED();
 }
 
-void fetch_inputfilepath(char*, int) {
+void fetch_inputfilepath(char *out, int) {
+    *out = 0;
     UNIMPLEMENTED();
 }
 
-void fetch_ripperpath(char*, int) {
+void fetch_ripperpath(char *out, int) {
+    *out = 0;
     UNIMPLEMENTED();
 }
 
-void fetch_rompath(char*, int) {
+void fetch_rompath(char *out, int) {
+    *out = 0;
     UNIMPLEMENTED();
 }
 
-void fetch_saveimagepath(char*, int, int) {
+void fetch_saveimagepath(char *out, int, int) {
+    *out = 0;
     TRACE();
 }
 
-void fetch_videopath(char*, int) {
+void fetch_videopath(char *out, int) {
+    *out = 0;
     UNIMPLEMENTED();
 }
 

--- a/src/dummy.cpp
+++ b/src/dummy.cpp
@@ -777,27 +777,27 @@ void fastlane_add_scsi_unit(int, uaedev_config_info*, romconfig*) {
     UNIMPLEMENTED();
 }
 
-void fetch_inputfilepath(char *out, int) {
+void fetch_inputfilepath(char* out, int) {
     *out = 0;
     UNIMPLEMENTED();
 }
 
-void fetch_ripperpath(char *out, int) {
+void fetch_ripperpath(char* out, int) {
     *out = 0;
     UNIMPLEMENTED();
 }
 
-void fetch_rompath(char *out, int) {
+void fetch_rompath(char* out, int) {
     *out = 0;
     UNIMPLEMENTED();
 }
 
-void fetch_saveimagepath(char *out, int, int) {
+void fetch_saveimagepath(char* out, int, int) {
     *out = 0;
     TRACE();
 }
 
-void fetch_videopath(char *out, int) {
+void fetch_videopath(char* out, int) {
     *out = 0;
     UNIMPLEMENTED();
 }

--- a/src/machdep/maccess.h
+++ b/src/machdep/maccess.h
@@ -24,6 +24,7 @@ STATIC_INLINE void do_put_mem_byte(uae_u8* a, uae_u8 v) {
 
 #ifdef _WIN32
 
+#ifdef HAVE_MOVBE
 #include <immintrin.h>
 
 STATIC_INLINE uae_u64 do_get_mem_quad(uae_u64* a) {
@@ -49,6 +50,33 @@ STATIC_INLINE void do_put_mem_long(uae_u32* a, uae_u32 v) {
 STATIC_INLINE void do_put_mem_word(uae_u16* a, uae_u16 v) {
     _store_be_u16(a, v);
 }
+#else /* HAVE_MOVBE */
+
+STATIC_INLINE uae_u64 do_get_mem_quad(uae_u64* a) {
+    return _byteswap_uint64(*a);
+}
+
+STATIC_INLINE uae_u32 do_get_mem_long(uae_u32* a) {
+    return _byteswap_ulong(*a);
+}
+
+STATIC_INLINE uae_u16 do_get_mem_word(uae_u16* a) {
+    return _byteswap_ushort(*a);
+}
+
+STATIC_INLINE void do_put_mem_quad(uae_u64* a, uae_u64 v) {
+    *a = _byteswap_uint64(v);
+}
+
+STATIC_INLINE void do_put_mem_long(uae_u32* a, uae_u32 v) {
+    *a = _byteswap_ulong(v);
+}
+
+STATIC_INLINE void do_put_mem_word(uae_u16* a, uae_u16 v) {
+    *a = _byteswap_ushort(v);
+}
+
+#endif /* HAVE_MOVBE */
 
 STATIC_INLINE uae_u64 do_byteswap_64(uae_u64 v) {
     return _byteswap_uint64(v);


### PR DESCRIPTION
1.
- The problem with memory stack corruption occurred in the 'fetch_saveimagepath()' function when starting the emulator. Because the memory allocated on the stack `TCHAR path[MAX_DPATH]` in function `DISK_get_default_saveimagepath` does not have a end of line marker ('/0'). That's why further call of the strcat() function which first searches for a zero byte and then adds another string to it resulted in stack corruption in this place and application crash as a consequence.
In other similar functions, the same scenario is possible.
2.
 I'm sorry, seems to I don't really know GitHub yet.
Because I made second comit with the optional enabling of SSE3 instructions (like 'movbe'). But they merged into one pull-request.