### PR TITLE
Fix to play SDL_audio on current device by default

### DIFF
--- a/src/sounddep/sound.cpp
+++ b/src/sounddep/sound.cpp
@@ -365,15 +365,19 @@ void resume_sound_device(struct sound_data* sd) {
 
 int get_default_audio_device() {
     int device_idx = -1;
+#if SDL_VERSION_ATLEAST(2, 24, 0)
     SDL_AudioSpec spec;
-    char* cur_driver = nullptr;
-    if (SDL_GetDefaultAudioInfo(&cur_driver, &spec, 0) == 0) {
+    char* default_device_name = nullptr;
+    if (SDL_GetDefaultAudioInfo(&default_device_name, &spec, 0) == 0) {
         for (int i = 0; i < num_sound_devices; i++) {
-            if (strcmp(sound_devices[i]->name, cur_driver) == 0)
-                device_idx = i;
+            if (strcmp(sound_devices[i]->name, default_device_name) != 0)
+                continue;
+            device_idx = i;
+            break;
         }
-        SDL_free(cur_driver);
+        SDL_free(default_device_name);
     }
+#endif
     return device_idx;
 }
 

--- a/uae_src/cfgfile.cpp
+++ b/uae_src/cfgfile.cpp
@@ -8389,6 +8389,7 @@ void default_prefs (struct uae_prefs *p, bool reset, int type)
 	p->keyboard_connected = true;
 
 	p->produce_sound = 3;
+	p->win32_soundcard = -1;
 	p->sound_stereo = SND_STEREO;
 	p->sound_stereo_separation = 7;
 	p->sound_mixed_stereo_delay = 0;


### PR DESCRIPTION
- There was no sound in quaesar because it uses the sound SDL_Audio device at index 0, not the current audio device in the OS. So now it will choose the current OS audio device unless the user has explicitly specified a different device in the config.