### PR TITLE
Fixed va_args being null crash

### DIFF
--- a/src/debugger/window/copper_wnd.cpp
+++ b/src/debugger/window/copper_wnd.cpp
@@ -211,13 +211,11 @@ void CopperDbgWnd::drawContent() {
             ImGui::TableNextColumn();
 
             // col:addr
-            strAddr.sprintf("%06X", (uint32_t)curAddr);
-            ImGui::TextColoredV(uiGetColorF(UiStyle::DisasmWnd_Addr), strAddr.c_str(), nullptr);
+            ImGui::TextColored(uiGetColorF(UiStyle::DisasmWnd_Addr),"%06X", curAddr);
             ImGui::TableNextColumn();
 
             // col:code bytes
-            strTmp.sprintf("%04X %04X", curEntry.w1, curEntry.w2);
-            ImGui::TextColoredV(uiGetColorF(UiStyle::DisasmWnd_OpCodeBytes), strTmp.c_str(), nullptr);
+            ImGui::TextColored(uiGetColorF(UiStyle::DisasmWnd_OpCodeBytes),"%04X %04X", curEntry.w1, curEntry.w2);
             ImGui::TableNextColumn();
 
             // col:instr

--- a/src/debugger/window/custom_regs_wnd.cpp
+++ b/src/debugger/window/custom_regs_wnd.cpp
@@ -51,7 +51,7 @@ void FlagsTooltipContent::_drawRegCols(const CustomFlagsDesc* fd, int b, uint16_
     ImGui::TextColored(uiGetColorF(UiStyle::CustomRegsWnd_RegName), "%02i", cb.noBeg);
     ImGui::TableNextColumn();
 
-    ImGui::TextColoredV(uiGetColorF(UiStyle::CustomRegsWnd_RegName), cb.name.data(), nullptr);
+    ImGui::TextColored(uiGetColorF(UiStyle::CustomRegsWnd_RegName), "%s", cb.name.data());
     ImGui::TableNextColumn();
 
     int bitsVal = (rv >> cb.shiftL) & cb.mask;
@@ -64,7 +64,7 @@ struct DrawCustomRegColumn {
     qd::VM::CustomRegs* custRegs;
     void drawColumn(CustReg reg_id) {
         stReg.assign(reg_id.toString().begin(), reg_id.toString().end());
-        ImGui::TextColoredV(uiGetColorF(UiStyle::CustomRegsWnd_RegName), stReg.c_str(), nullptr);
+        ImGui::TextColored(uiGetColorF(UiStyle::CustomRegsWnd_RegName), "%s", stReg.c_str());
 
         if (ImGui::BeginItemTooltip()) {
             FlagsTooltipContent flgContent;

--- a/src/debugger/window/disassembly_wnd.cpp
+++ b/src/debugger/window/disassembly_wnd.cpp
@@ -99,7 +99,7 @@ void DisassemblyView::drawContent() {
             for (int b = 0; b < entry.size; ++b) {
                 strTmp.append_sprintf("%02X", entry.bytes[b]);
             }
-            ImGui::TextColoredV(uiGetColorF(UiStyle::DisasmWnd_OpCodeBytes), strTmp.c_str(), nullptr);
+            ImGui::TextColored(uiGetColorF(UiStyle::DisasmWnd_OpCodeBytes), "%s", strTmp.c_str());
             ImGui::TableNextColumn();
             // col:instr
             strTmp = entry.mnemonic;

--- a/src/debugger/window/registers_wnd.cpp
+++ b/src/debugger/window/registers_wnd.cpp
@@ -39,7 +39,7 @@ void RegistersView::drawContent() {
 
             // Ax col
             ImGui::PushStyleColor(ImGuiCol_Text, uiGetColorU(UiStyle::RegistersWnd_RegName));
-            ImGui::TextV(stReg.sprintf("A%d", i).c_str(), nullptr);
+            ImGui::Text("A%d", i);
             ImGui::PopStyleColor();
             ImGui::TableNextColumn();
             editCommonRegVal(cpu->getRegA(i));
@@ -47,7 +47,7 @@ void RegistersView::drawContent() {
 
             // Dx col
             ImGui::PushStyleColor(ImGuiCol_Text, uiGetColorU(UiStyle::RegistersWnd_RegName));
-            ImGui::TextV(stReg.sprintf("D%d", i).c_str(), nullptr);
+            ImGui::Text("D%d", i);
             ImGui::PopStyleColor();
             ImGui::TableNextColumn();
             editCommonRegVal(cpu->getRegD(i));
@@ -60,7 +60,7 @@ void RegistersView::drawContent() {
 
             // PC
             ImGui::PushStyleColor(ImGuiCol_Text, uiGetColorU(UiStyle::RegistersWnd_RegName));
-            ImGui::TextV(stReg.sprintf("PC").c_str(), nullptr);
+            ImGui::Text("PC");
             ImGui::PopStyleColor();
             ImGui::TableNextColumn();
             editCommonRegVal(cpu->getPC());


### PR DESCRIPTION
I noticed I get crashes here
```
* thread #1, name = 'quaesar', stop reason = signal SIGSEGV: address not mapped to object (fault address: 0x0)
  * frame #0: 0x00007ffff79793fa libc.so.6`__printf_buffer(buf=0x00007fffffffc1d0, format="BLTDDAT", ap=0x0000000000000000, mode_flags=0) at vfprintf-internal.c:638:3
    frame #1: 0x00007ffff79a00d0 libc.so.6`___vsnprintf [inlined] __vsnprintf_internal(string=<unavailable>, maxlen=<unavailable>, format=<unavailable>, args=<unavailable>, mode_flags=0) at vsnprintf.c:96:3
    frame #2: 0x00007ffff79a008f libc.so.6`___vsnprintf(string=<unavailable>, maxlen=<unavailable>, format=<unavailable>, args=<unavailable>) at vsnprintf.c:103:10
    frame #3: 0x0000555556ba6c58 quaesar`ImFormatStringV(char*, unsigned long, char const*, __va_list_tag*) + 48
    frame #4: 0x0000555556ba6fae quaesar`ImFormatStringToTempBufferV(char const**, char const**, char const*, __va_list_tag*) + 579
    frame #5: 0x0000555556c751fe quaesar`ImGui::TextV(char const*, __va_list_tag*) + 79
    frame #6: 0x0000555556c75339 quaesar`ImGui::TextColoredV(ImVec4 const&, char const*, __va_list_tag*) + 56
    frame #7: 0x0000555556b12323 quaesar`qd::window::DrawCustomRegColumn::drawColumn(qd::CustReg) + 143
    frame #8: 0x0000555556b11dd5 quaesar`qd::window::CustomRegsWnd::drawContent() + 789
    frame #9: 0x0000555556b83c0f quaesar`qd::UiWindow::draw() + 85
    frame #10: 0x0000555556b8169b quaesar`qd::GuiManager::_drawDebuggerWindows() + 173
    frame #11: 0x0000555556b8107e quaesar`qd::GuiManager::drawImGuiMainFrame() + 214
    frame #12: 0x0000555556aff842 quaesar`qd::Debugger::update() + 56
    frame #13: 0x0000555556b297a2 quaesar`qd::App::mainLoop() + 256
    frame #14: 0x0000555556b2928c quaesar`main + 1808
```
Which is due to a bunch of code is using `Text(Colered)V(.., nullptr)` that is being passed in with `va_args` being `nullptr` that crashes. Now this isn't being used and I also simplified some code while doing the clean up.

cc @dartfnm 