### PR TITLE
Update UAE texture on main thread

### DIFF
--- a/src/dummy.cpp
+++ b/src/dummy.cpp
@@ -958,22 +958,24 @@ bool render_screen(int /*monid*/, int, bool) {
 
 void unlockscr(struct vidbuffer* vb_in, int /*y_start*/, int /*y_end*/) {
     // copy UAE screen to texture buf
-    if (uint32_t* pixels = app->lockUaeScreenTexBuf()) {
-        struct vidbuf_description* avidinfo = &adisplays[vb_in->monitor_id].gfxvidinfo;
-        struct vidbuffer* vb = avidinfo->outbuffer;
+    struct vidbuf_description* avidinfo = &adisplays[vb_in->monitor_id].gfxvidinfo;
+    struct vidbuffer* vb = avidinfo->outbuffer;
 
-        if (vb && vb->bufmem) {
-            uint8_t* sptr = vb->bufmem;
-            int amiga_width = vb->outwidth;
-            int amiga_height = vb->outheight;
+    if (!vb || !vb->bufmem) {
+        return;
+    }
 
-            // Change pixels
-            for (int y = 0; y < amiga_height; y++) {
-                uint8_t* dest = (uint8_t*)&pixels[y * 754];
-                memcpy(dest, sptr, amiga_width * 4);
-                sptr += vb->rowbytes;
-            }
+    uint8_t* sptr = vb->bufmem;
+    int amiga_width = vb->outwidth;
+    int amiga_height = vb->outheight;
+
+    if (uint32_t* pixels = app->lockUaeScreenTexBuf(amiga_width, amiga_height)) {
+        for (int y = 0; y < amiga_height; y++) {
+            uint8_t* dest = (uint8_t*)&pixels[y * amiga_width];
+            memcpy(dest, sptr, amiga_width * 4);
+            sptr += vb->rowbytes;
         }
+
         app->unlockUaeScreenTexBuf();
     }
 }

--- a/src/quaesar.cpp
+++ b/src/quaesar.cpp
@@ -211,15 +211,10 @@ void App::destroyUaeWindow() {
 
 
 void App::createUaeWindow() {
-    const int amiga_width = 754;
-    const int amiga_height = 576;
-    int wndWidth = amiga_width;
-    int wndHeight = amiga_height;
-
     SDL_AtomicSet(&scrFrameNo, 0);
 
     // Create a window
-    app->mUaeWindow = SDL_CreateWindow("Quaesar", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, wndWidth, wndHeight,
+    app->mUaeWindow = SDL_CreateWindow("Quaesar", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, mAmigaWidth, mAmigaHeight,
                                        SDL_WINDOW_RESIZABLE);
 
     if (!app->mUaeWindow) {
@@ -235,8 +230,8 @@ void App::createUaeWindow() {
         return;
     }
 
-    mUaeScrTexture = SDL_CreateTexture(mUaeRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, amiga_width,
-                                       amiga_height);
+    mUaeScrTexture = SDL_CreateTexture(mUaeRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING,
+                                       mAmigaWidth, mAmigaHeight);
 
     if (!mUaeScrTexture) {
         SDL_Log("Could not create texture: %s", SDL_GetError());
@@ -244,8 +239,36 @@ void App::createUaeWindow() {
         SDL_DestroyWindow(mUaeWindow);
         return;
     }
+
+    mAmigaBuffer = new uint32_t[mAmigaWidth * mAmigaHeight];
 }
 
+ // Function to recreate a dynamic texture with new dimensions
+void App::recreateTexture(int newWidth, int newHeight) {
+    int currentWidth = 0;
+    int currentHeight = 0;
+
+    // Get the format of the old texture
+    Uint32 format;
+    int access;
+    SDL_QueryTexture(mUaeScrTexture, &format, &access, &currentWidth, &currentHeight);
+
+    if (newWidth == currentWidth && newHeight == currentHeight) {
+        return;
+    }
+
+    // Destroy the old texture
+    SDL_DestroyTexture(mUaeScrTexture);
+
+    // Create a new texture with the desired dimensions
+    mUaeScrTexture = SDL_CreateTexture(
+        mUaeRenderer,
+        format,
+        access,  // Using the same access pattern as the original
+        newWidth,
+        newHeight
+    );
+}
 
 void App::renderUaeWindow() {
     // render UAE texture screen
@@ -253,17 +276,16 @@ void App::renderUaeWindow() {
     if (curFrame == renderedFrameNo) {
         return;
     }
+
     renderedFrameNo = curFrame;
 
-    int amiga_width = 754;
-    int amiga_height = 576;
     int new_width = 0;
     int new_height = 0;
     int window_width, window_height;
     SDL_GetWindowSize(mUaeWindow, &window_width, &window_height);
 
     // Maintain aspect ratio
-    float image_aspect = (float)amiga_width / (float)amiga_height;
+    float image_aspect = (float)mAmigaWidth / (float)mAmigaHeight;
     float window_aspect = (float)window_width / (float)window_height;
 
     if (window_aspect < image_aspect) {
@@ -276,6 +298,17 @@ void App::renderUaeWindow() {
     SDL_Rect rect = {(window_width - new_width) / 2, (window_height - new_height) / 2, new_width, new_height};
     SDL_RenderClear(mUaeRenderer);
     if (mUaeScrTextureMutex.tryLock()) {
+        recreateTexture(mAmigaWidth, mAmigaHeight); // Recreate texture if needed
+        uint32_t* texture_pixels = nullptr;
+        int pitch = 0;
+        if (SDL_LockTexture(mUaeScrTexture, NULL, (void**)&texture_pixels, &pitch) == 0) {
+            for (int y = 0; y < mAmigaHeight; y++) {
+                uint8_t* dest = (uint8_t*)&texture_pixels[y * mAmigaWidth];
+                memcpy(dest, &mAmigaBuffer[y * mAmigaWidth], mAmigaWidth * 4);
+            }
+            SDL_UnlockTexture(mUaeScrTexture);
+        }
+
         SDL_RenderCopy(mUaeRenderer, mUaeScrTexture, NULL, &rect);
         SDL_RenderPresent(mUaeRenderer);
         mUaeScrTextureMutex.unlock();
@@ -283,15 +316,19 @@ void App::renderUaeWindow() {
 }
 
 
-uint32_t* App::lockUaeScreenTexBuf() {
+uint32_t* App::lockUaeScreenTexBuf(int amiga_width, int amiga_height) {
     mUaeScrTextureMutex.lock();
     uint32_t* pixels = nullptr;
-    int pitch = 0;
-    if (SDL_LockTexture(mUaeScrTexture, NULL, (void**)&pixels, &pitch) == 0) {
-        return pixels;
+
+    if (amiga_width > mAmigaWidth || mAmigaHeight > amiga_height) {
+        delete [] mAmigaBuffer;
+        mAmigaBuffer = new uint32_t[mAmigaWidth * mAmigaHeight];
     }
-    mUaeScrTextureMutex.unlock();
-    return nullptr;
+
+    mAmigaWidth = amiga_width;
+    mAmigaHeight = amiga_height;
+
+    return pixels;
 }
 
 

--- a/src/quaesar.h
+++ b/src/quaesar.h
@@ -19,6 +19,9 @@ class App {
     SDL_atomic_t scrFrameNo = {};
     int renderedFrameNo = -1;
     bool mQuitRequestPosted = false;
+    int mAmigaWidth = 754;
+    int mAmigaHeight = 576;
+    uint32_t* mAmigaBuffer = nullptr;
 
 public:
     qd::Debugger* mDebugger = nullptr;
@@ -32,7 +35,7 @@ public:
     void requestToQuit();
     bool hasQuitRequest() const;
 
-    uint32_t* lockUaeScreenTexBuf();
+    uint32_t* lockUaeScreenTexBuf(int amiga_width, int amiga_height);
     void unlockUaeScreenTexBuf();
 
     qd::Debugger* getDbg() const {
@@ -48,6 +51,8 @@ private:
     void createUaeWindow();
     void renderUaeWindow();
     void destroyUaeWindow();
+    void recreateTexture(int newWidth, int newHeight);
+
 
 };  // class App
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This moves the update of the UAE texture to the main thread instead. It's not supported to lock the textures on a different thread and while it may work on some backends (such as Windows) it's not fully supported. By fixing this everything started to work again (I had an issue where the dear imgui window wouldn't update as well) after the fix in here everything seems work as should.

Also while it it I added support if the Amiga display screen would change in size. I'm not sure if this is common or not from the emulation standpoint, but now it's more supported at least even if there are likely some more cases that needs to be fixed.

cc @dartfnm 

![quaesar](https://github.com/user-attachments/assets/dd353f2a-698e-4f5b-943f-2c9afa522454)
